### PR TITLE
Updates the app.js documentation to use configFile

### DIFF
--- a/jive-sdk-service/generator/base/app.js
+++ b/jive-sdk-service/generator/base/app.js
@@ -78,7 +78,7 @@ required to start the service (clientUrl, port), or the location of a JSON
 file containing those setup options.
 
 If no 2nd argument is provided, then the system will try to locate a command line parameter to
-node called config (eg. config=/path/to/my.json), or an environment variable (eg. CONFIG_FILE=/path/to/my.json).
+node called config (eg. configFile=/path/to/my.json), or an environment variable (eg. CONFIG_FILE=/path/to/my.json).
 
 If neither are present, the system will assume that a file [app root]/jiveclientconfiguration.json] exists, and
 will try to parse that file for options.


### PR DESCRIPTION
The inline documentation for app.js has an example with
`config=/path/to/my.json` as a command line argument while the
service.js obviously looks for a `configFile=/path/to/my.json` command
line argument.

This targets issue #28. 
I tried to create a test case in test/unit/setup/testcases/setup.js but wan't able to pass a command line argument. If anybody can show me how to do it, I would gladly update the PR with a test case.
