### PR TITLE
Changes fsSimpleRename to use mv

### DIFF
--- a/jive-sdk-api/lib/util/jiveutil.js
+++ b/jive-sdk-api/lib/util/jiveutil.js
@@ -24,6 +24,7 @@
 
 var q = require('q');
 var fs = require('fs-extra');
+var mv = require('mv');
 var uuid = require('node-uuid');
 var mustache = require('mustache');
 var jive = require('../../api');
@@ -162,7 +163,7 @@ exports.fscopy = function (source, target) {
 var fsSimpleRename = function (source, target) {
     var deferred = q.defer();
 
-    fs.rename(source, target, function (err) {
+    mv(source, target, function (err) {
         if (err) {
             deferred.reject(err);
         }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "archiver" : "0.4.9",
     "http-proxy" : "*",
     "stream-array" : "*",
-    "traverse" : "0.6.6"
+    "traverse" : "0.6.6",
+    "mv" : "~2.0.3"
   },
   "devDependencies": {
     "grunt": "~0.4.2",


### PR DESCRIPTION
fsSimpleRename in jiveutil.js uses fs.rename which doesn't work cross-filesystems (see issue #22). This commit changes it to use npm mv (https://www.npmjs.org/package/mv). MV tries fs.rename first and uses fallbacks if it doesn't work.
