### PR TITLE
Only the dot-prefixed DS_Store needs to be ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 node_modules/
 .idea/
 *.iml
-DS_Store
 .DS_Store
 /.project


### PR DESCRIPTION
I know this is minor, @ryanrutan, but I love tidy .gitignore files. I think the non-dot version of DS_Store can be safely removed, as I don't know of a scenario in which that can be created.  Let me know if you've seen a situation in which it can.  Otherwise, let's merge this safe little bit of polish.
