### PR TITLE
HTTP is a more behind-the-firewall accessible protocol than git://

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/jivesoftware/jive-sdk"
+    "url": "http://github.com/jivesoftware/jive-sdk"
   },
   "keywords": [
     "jive",


### PR DESCRIPTION
Many of our customers are behind firewalls. Let's make it easier for them to access our repository by toggling from the aging git:// protocol to the more firewall-friendly and equally as performant http:// URL for this project.

This is documented as the Node standard about half way down their documentation page at https://www.npmjs.org/doc/files/package.json.html

CC @ryanrutan 
