### PR TITLE
Fix security middleware to see  routes as case-insensitive

### DIFF
--- a/jive-sdk-service/lib/security.js
+++ b/jive-sdk-service/lib/security.js
@@ -108,7 +108,7 @@ exports.lockRoute = function( routePath ) {
     }
 
     var key = routePath['verb'] + '.' + routePath['path'];
-    lockedRoutes[key] = routePath;
+    lockedRoutes[key.toLowerCase()] = routePath;
 };
 
 exports.getLockedRoutes = function() {
@@ -122,8 +122,8 @@ exports.isLocked = function( req ) {
         return false;
     }
 
-    var key = req.method.toLowerCase() + '.' + req.path;
-    return lockedRoutes[key];
+    var key = req.method + '.' + req.path;
+    return lockedRoutes[key.toLowerCase()];
 };
 
 function invalidAuthResponse(res) {


### PR DESCRIPTION
The Node SDK security middleware does not lock routes in a case-insensitive way when using the "jiveLocked" flag.

When routes are created with Express, they are by default case-insensitive. That is, a request to “/sampleRoute” is the same as a request to “/sampleROUTE”.

On the other hand, the “jiveLocked” flag only behaves in a case-sensitive way. If I lock down “/ secretRoute” using the flag, but then try to access “/SECRETroute”, I am able to access the locked down route. A 403 Unauthorized error would be expected, but that is only displayed for the “/secretRoute” with case-sensitive spelling.

**Reproduction Steps**
1. Lock a route made using the Node SDK Express middleware using the “jiveLocked” flag.
2. Access the route using a different case spelling.
3. An unauthorized user is able to access the route that was supposed to be locked to only
Jive.

**Fix**
The issue appears to be with how the lockedRoutes object is treated in the file “/jive-sdk- service/lib/security.js”. Keys are inserted into this object in a case-sensitive way. Instead, keys should always be inserted as lowercase. When searching for a specific locked route, the search should be performed on the lowercase string, this way the same route with a different casing will be treated as the same route.